### PR TITLE
BAN-148: Fix Sonnet continuing conversation instead of summarising

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seamless-claude",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Zero-downtime compaction for Claude Code. Pre-compacts sessions in the background so you never wait for context summarisation.",
   "author": {
     "name": "RemoteCTO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ here. Format follows [Keep a Changelog][kac].
 
 [kac]: https://keepachangelog.com/en/1.1.0/
 
+## [0.2.1] — 2026-02-16
+
+### Fixed
+
+- **Sonnet conversation continuation bug**: Sonnet
+  treated the transcript as a conversation to continue
+  rather than data to summarise, producing short
+  in-character responses instead of structured summaries.
+  Fixed by reframing the system prompt as a
+  "SUMMARISATION TOOL" with explicit anti-roleplay
+  instructions, wrapping the transcript in XML tags to
+  create a clear data boundary, and adding a closing
+  instruction to start with "## Session Summary".
+- **Prompt section numbering removed**: numbered
+  prefixes (`### 1. Session Summary`) replaced with
+  plain headings (`## Session Summary`) to reduce
+  ambiguity for the model.
+
+### Changed
+
+- Transcript input wrapped in `<transcript>` XML tags
+  instead of bare text after a `---` separator. Prevents
+  models from treating USER/ASSISTANT entries as
+  conversational context.
+- System prompt explicitly lists all required section
+  headings by name and instructs the model to start
+  output with "## Session Summary".
+- Default prompt now requests at least 2000 characters
+  of output to prevent terse summaries.
+- Plugin manifest version synced with package.json.
+
 ## [0.2.0] — 2026-02-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seamless-claude",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Zero-downtime compaction for Claude Code. Pre-compacts sessions in the background so you never wait.",
   "type": "module",
   "bin": {

--- a/scripts/compactor.mjs
+++ b/scripts/compactor.mjs
@@ -99,19 +99,18 @@ Include any open questions or blockers.
 - Aim for at least 2000 characters of output
 - Start your response with "## Session Summary"`
 
-const SYSTEM_PROMPT =
+const SYSTEM_BASE =
   'You are a SUMMARISATION TOOL, not a ' +
   'conversational assistant. You receive a ' +
   'transcript of a past coding session as INPUT ' +
   'DATA. Do NOT continue the conversation. Do ' +
   'NOT respond as if you are the assistant in ' +
   'that transcript. ANALYSE the transcript and ' +
-  'produce a structured markdown summary with ' +
-  'these exact headings: "## Session Summary", ' +
-  '"## Technical Context", "## User Intent", ' +
-  '"## Knowledge Extractions", "## Next Steps", ' +
-  '"## Active Context". Start your response ' +
-  'with "## Session Summary".'
+  'produce a structured markdown summary '
+
+const SYSTEM_DEFAULT = `${SYSTEM_BASE}with these exact headings: "## Session Summary", "## Technical Context", "## User Intent", "## Knowledge Extractions", "## Next Steps", "## Active Context". Start your response with "## Session Summary".`
+
+const SYSTEM_CUSTOM = `${SYSTEM_BASE}following the exact format specified in the user message.`
 
 // Custom prompt file overrides default
 let activePrompt = PROMPT
@@ -187,7 +186,7 @@ async function main() {
     '--output-format',
     'text',
     '--system-prompt',
-    SYSTEM_PROMPT,
+    usingCustomPrompt ? SYSTEM_CUSTOM : SYSTEM_DEFAULT,
   ]
 
   let result = null


### PR DESCRIPTION
Sonnet treated `USER:`/`ASSISTANT:` transcript entries as a
conversation to continue, producing ~700 char in-character
responses instead of structured summaries. Both retry attempts
failed validation, leaving sessions unresumable.

**Root cause**: The system prompt and input framing were too
weak — Sonnet couldn't distinguish between "here is a
conversation to summarise" and "here is a conversation to
continue".

## Changes

- **System prompt** reframed as "SUMMARISATION TOOL" with
  explicit anti-roleplay instructions. Conditional: uses
  generic format instructions when `SEAMLESS_PROMPT_FILE`
  is active to avoid heading conflicts with custom prompts.
- **Transcript wrapping** in `<transcript>` XML tags creates
  a clear data boundary between instructions and input.
- **Closing instruction** appended after the transcript:
  "Produce the structured summary now."
- **User prompt** restructured: numbered section prefixes
  removed (`### 1.` → `## `), explicit "include ALL six
  sections" rule, 2000 char minimum target.
- **Plugin manifest** version synced with package.json.

## Test plan

- [x] Manual compaction of failed session `db080aef` —
  produced 15,735 chars valid output (was 676/716 chars)
- [x] All 158 existing tests passing
- [x] Biome lint clean
- [x] Validated against real 75K char infrastructure
  transcript (326 entries)
