### PR TITLE
BAN-300: Add upstream compatibility check script

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "seamless-claude",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Zero-downtime compaction for Claude Code. Pre-compacts sessions in the background so you never wait for context summarisation.",
   "author": {
     "name": "RemoteCTO"

--- a/.compat-baseline
+++ b/.compat-baseline
@@ -1,0 +1,5 @@
+{
+  "version": "2.1.44",
+  "checked_at": "2026-02-16T12:00:00Z",
+  "seamless_version": "0.2.1"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ here. Format follows [Keep a Changelog][kac].
 
 [kac]: https://keepachangelog.com/en/1.1.0/
 
+## [0.2.2] — 2026-02-24
+
+### Added
+
+- **Upstream compatibility check** (`npm run compat`):
+  compares installed Claude Code version against a
+  tracked baseline, scans GitHub release notes for
+  keywords matching the integration surface (hooks,
+  statusline, transcripts, `claude -p` flags), and
+  runs a contract smoke test. Reports matches for
+  manual review. Run with `--update` to set a new
+  baseline after reviewing.
+
 ## [0.2.1] — 2026-02-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seamless-claude",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Zero-downtime compaction for Claude Code. Pre-compacts sessions in the background so you never wait.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "node --test test/*.test.mjs",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "compat": "node scripts/check-upstream.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-upstream.mjs
+++ b/scripts/check-upstream.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Compatibility check for Claude Code upstream changes.
+ *
+ * Compares installed Claude Code version against the
+ * tracked baseline, scans release notes for keywords
+ * that touch our integration surface, and runs a
+ * contract smoke test.
+ *
+ * Usage: node scripts/check-upstream.mjs [--update]
+ */
+
+import { execSync, spawn } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const BASELINE_PATH = join(ROOT, '.compat-baseline')
+const UPDATE = process.argv.includes('--update')
+
+const KEYWORDS = [
+  'hook',
+  'PreCompact',
+  'SessionStart',
+  'UserPromptSubmit',
+  'statusLine',
+  'statusline',
+  'compac',
+  'autocompact',
+  'transcript',
+  'plugin',
+  '-p ',
+  'stream-json',
+  'CLAUDECODE',
+  'context_window',
+  'session_id',
+  'print mode',
+]
+
+function getInstalledVersion() {
+  try {
+    const raw = execSync('claude --version', {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim()
+    const match = raw.match(/(\d+\.\d+\.\d+)/)
+    return match ? match[1] : null
+  } catch {
+    return null
+  }
+}
+
+function readBaseline() {
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  }
+  return 0
+}
+
+async function fetchReleases(baseline, current) {
+  const url =
+    'https://api.github.com/repos/' +
+    'anthropics/claude-code/releases?per_page=50'
+  const res = await fetch(url, {
+    headers: { Accept: 'application/vnd.github+json' },
+  })
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status}: ${res.statusText}`)
+  }
+  const releases = await res.json()
+  return releases.filter((r) => {
+    const m = r.tag_name.match(/(\d+\.\d+\.\d+)/)
+    if (!m) return false
+    const v = m[1]
+    return (
+      compareVersions(v, baseline) > 0 &&
+      compareVersions(v, current) <= 0
+    )
+  })
+}
+
+function scanRelease(release) {
+  const body = release.body || ''
+  const tag = release.tag_name
+  const matches = []
+  for (const kw of KEYWORDS) {
+    if (body.includes(kw)) {
+      const line = body.split('\n').find((l) => l.includes(kw))
+      const context = line ? line.trim().slice(0, 60) : '(in body)'
+      matches.push({ tag, keyword: kw, context })
+    }
+  }
+  return matches
+}
+
+function runContractTest() {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const child = spawn(
+      'claude',
+      [
+        '-p',
+        '--model',
+        'sonnet',
+        '--no-session-persistence',
+        '--output-format',
+        'text',
+        '--system-prompt',
+        'test',
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    )
+
+    let stdout = ''
+    child.stdout.on('data', (d) => {
+      stdout += d.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill()
+      resolve({ pass: false, reason: 'timeout (15s)' })
+    }, 15000)
+
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve({
+        pass: false,
+        reason: 'claude binary not found',
+      })
+    })
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      const elapsed = ((Date.now() - start) / 1000).toFixed(1)
+      if (code === 0 && stdout.length > 0) {
+        resolve({ pass: true, elapsed })
+      } else {
+        resolve({
+          pass: false,
+          reason: `exit ${code}, ${stdout.length} bytes`,
+        })
+      }
+    })
+
+    child.stdin.write('reply OK')
+    child.stdin.end()
+  })
+}
+
+async function main() {
+  const current = getInstalledVersion()
+  if (!current) {
+    console.error('Could not detect Claude Code version.')
+    process.exit(1)
+  }
+
+  const baseline = readBaseline()
+  if (!baseline) {
+    console.error(
+      'No .compat-baseline found. Run with --update' +
+        ' to create one.',
+    )
+    process.exit(1)
+  }
+
+  console.log('seamless-claude compatibility check')
+  console.log('====================================')
+  console.log(
+    `Baseline: ${baseline.version}` +
+      ` (${baseline.checked_at.slice(0, 10)})`,
+  )
+  console.log(`Current:  ${current}`)
+
+  if (compareVersions(current, baseline.version) <= 0) {
+    console.log('\nUp to date. No new releases.\n')
+    process.exit(0)
+  }
+
+  const releases = await fetchReleases(baseline.version, current)
+  console.log(`Releases: ${releases.length}\n`)
+
+  const allMatches = releases.flatMap(scanRelease)
+
+  console.log('## Keyword Matches')
+  if (allMatches.length === 0) {
+    console.log('None — no integration surface hits.\n')
+  } else {
+    for (const m of allMatches) {
+      console.log(`${m.tag}: "${m.keyword}" (${m.context})`)
+    }
+    console.log()
+  }
+
+  console.log('## Contract Test')
+  const test = await runContractTest()
+  if (test.pass) {
+    console.log(`claude -p: PASS (v${current}, ${test.elapsed}s)`)
+  } else {
+    console.log(`claude -p: FAIL (${test.reason})`)
+  }
+
+  console.log()
+  console.log('## Verdict')
+  if (allMatches.length === 0 && test.pass) {
+    console.log('CLEAR — no keyword matches, contract OK.')
+  } else if (allMatches.length > 0) {
+    const tags = [...new Set(allMatches.map((m) => m.tag))]
+    console.log(
+      `REVIEW NEEDED — ${allMatches.length} keyword` +
+        ` match(es) across ${tags.length} release(s).`,
+    )
+  }
+  if (!test.pass) {
+    console.log(`CONTRACT FAIL — ${test.reason}`)
+  }
+
+  console.log('\nRun with --update to set new baseline.\n')
+
+  if (UPDATE) {
+    const pkg = JSON.parse(
+      readFileSync(join(ROOT, 'package.json'), 'utf8'),
+    )
+    const data = {
+      version: current,
+      checked_at: new Date().toISOString(),
+      seamless_version: pkg.version,
+    }
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(data, null, 2)}\n`)
+    console.log(`.compat-baseline updated to ${current}.\n`)
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`)
+  process.exit(1)
+})

--- a/scripts/check-upstream.mjs
+++ b/scripts/check-upstream.mjs
@@ -167,6 +167,19 @@ async function main() {
 
   const baseline = readBaseline()
   if (!baseline) {
+    if (UPDATE) {
+      const pkg = JSON.parse(
+        readFileSync(join(ROOT, 'package.json'), 'utf8'),
+      )
+      const data = {
+        version: current,
+        checked_at: new Date().toISOString(),
+        seamless_version: pkg.version,
+      }
+      writeFileSync(BASELINE_PATH, `${JSON.stringify(data, null, 2)}\n`)
+      console.log(`.compat-baseline created at ${current}.\n`)
+      process.exit(0)
+    }
     console.error(
       'No .compat-baseline found. Run with --update' +
         ' to create one.',


### PR DESCRIPTION
Scans Claude Code release notes between the tracked baseline version and the installed version for keywords matching our integration surface (hooks, statusline, transcripts, claude -p flags). Runs a contract smoke test against claude -p. Reports matches for manual review.

## Description

Describe the changes in this pull request.

## Checklist

- [ ] Description of changes provided above
- [ ] Tests added or updated for new behaviour
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Documentation updated if needed (README, comments)

## Related Issues

Fixes #(issue number)
